### PR TITLE
workaround to pass env variables on windows with cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "axios": "^0.18.0",
     "concurrently": "^4.1.0",
+    "cross-env": "^5.2.0",
     "json-server": "^0.14.2",
     "lodash": "^4.17.11",
     "react-scripts": "^2.1.3",
@@ -24,7 +25,7 @@
   },
   "scripts": {
     "start": "concurrently 'npm:frontend' 'npm:api'",
-    "frontend": "PORT=5000 REACT_APP_API_URL=http://localhost:3000 react-scripts start",
+    "frontend": "cross-env PORT=5000 REACT_APP_API_URL=http://localhost:3000 react-scripts start",
     "api": "node --inspect server.js",
     "build": "react-scripts build",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Hi

I just started the cypress course and had a problem to pass the env variables using windows.
Using cross-env solved the problem (and should even work for linux and mac ;)

Hope this may help others and thanks for this course,
Pascal